### PR TITLE
HADOOP-18717. Move CodecPool logs to DEBUG scope

### DIFF
--- a/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/CodecPool.java
+++ b/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/io/compress/CodecPool.java
@@ -150,7 +150,9 @@ public class CodecPool {
     Compressor compressor = borrow(compressorPool, codec.getCompressorType());
     if (compressor == null) {
       compressor = codec.createCompressor();
-      LOG.info("Got brand-new compressor ["+codec.getDefaultExtension()+"]");
+      if(LOG.isDebugEnabled()) {
+        LOG.debug("Got brand-new compressor ["+codec.getDefaultExtension()+"]");
+      }
     } else {
       compressor.reinit(conf);
       if(LOG.isDebugEnabled()) {
@@ -181,7 +183,9 @@ public class CodecPool {
     Decompressor decompressor = borrow(decompressorPool, codec.getDecompressorType());
     if (decompressor == null) {
       decompressor = codec.createDecompressor();
-      LOG.info("Got brand-new decompressor ["+codec.getDefaultExtension()+"]");
+      if(LOG.isDebugEnabled()) {
+        LOG.debug("Got brand-new decompressor ["+codec.getDefaultExtension()+"]");
+      }
     } else {
       if(LOG.isDebugEnabled()) {
         LOG.debug("Got recycled decompressor");


### PR DESCRIPTION


### Description of PR
Jira: [HADOOP-18717](https://issues.apache.org/jira/browse/HADOOP-18717). As a Hadoop user, these logs get very noisy when reading thousands of blocks and don't add critical information.

### How was this patch tested?
automated test suite

### For code changes:

- [x] Does the title or this PR starts with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [ ] Object storage: have the integration tests been executed and the endpoint declared according to the connector-specific documentation?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] If applicable, have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?

